### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,42 +2,30 @@ name: test
 
 on:
   push:
+    branches:
+      - master
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-        go:
-          - "1.20"
-          - "1.19"
-          - "1.18"
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:12
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_DB: pgtxdbtest
+          POSTGRES_USER: pgtxdbtest
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
     steps:
-      - name: Prepare DB
-        run: |
-          psql -U postgres -h localhost -d postgres -c 'CREATE USER pgtxdbtest;'
-          psql -U postgres -h localhost -d postgres -c 'CREATE DATABASE pgtxdbtest OWNER pgtxdbtest;'
-      - name: Install Go
-        uses: actions/setup-go/@v2
+      - uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.go }}
-
-      - name: Checkout code
-        uses: actions/checkout/@v2
-
-      - name: Run test
-        run: go test -v
-
+          go-version-file: go.mod
+      - uses: actions/checkout@v2
+      - run: make test


### PR DESCRIPTION
CIのワークフローを修正します。

- golangci-lintで問題が出るためバージョンマトリクスを一つに統合
- 重複して走らないように concurrency を追加
- PRで複数CIが走らないように pushトリガの branchesをmasterに制限
- jobsの書き方をシンプルに

cc @hiroakis @achiku @mururu @kazukousen 